### PR TITLE
アルファチャンネルもピクセル化処理の対象にする

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,15 +9,20 @@ import os
 from models.module_photo2pixel2 import Photo2PixelModel
 from utils import img_common_util
 
-def convert(imagePath):
+def convert(imagePath, kernel_size=4, pixel_size=10, edge_thresh=2048):
     parser = argparse.ArgumentParser(description='algorithm converting photo to pixel art')
     parser.add_argument('--input', type=str, default="./" + imagePath, help='input image path')
-    parser.add_argument('-k', '--kernel_size', type=int, default=10, help='larger kernel size means smooth color transition')
-    parser.add_argument('-p', '--pixel_size', type=int, default=3, help='individual pixel size')
-    parser.add_argument('-e', '--edge_thresh', type=int, default=2048, help='lower edge threshold means more black line in edge region')
+    parser.add_argument('-k', '--kernel_size', type=int, default=kernel_size, help='larger kernel size means smooth color transition')
+    parser.add_argument('-p', '--pixel_size', type=int, default=pixel_size, help='individual pixel size')
+    parser.add_argument('-e', '--edge_thresh', type=int, default=edge_thresh, help='lower edge threshold means more black line in edge region')
     parser.add_argument('--resize', type=int, nargs=2, help='resize images to a fixed size (width height)')
-    args = parser.parse_args()
+    args = parser.parse_args([])  # 空のリストを渡してコマンドライン引数を無視
 
+    # 引数で渡された値を使用
+    args.kernel_size = kernel_size
+    args.pixel_size = pixel_size
+    args.edge_thresh = edge_thresh
+    
     # 出力ファイル名を生成
     base_name = os.path.basename(imagePath)
     file_name, file_extension = os.path.splitext(base_name)
@@ -88,4 +93,4 @@ if __name__ == '__main__':
     png_images = find_png_images(directory)
     for image in png_images:
         print(image)
-        convert(image)
+        convert(image, kernel_size=16, pixel_size=10, edge_thresh=2048)

--- a/main.py
+++ b/main.py
@@ -12,13 +12,18 @@ from utils import img_common_util
 def convert(imagePath):
     parser = argparse.ArgumentParser(description='algorithm converting photo to pixel art')
     parser.add_argument('--input', type=str, default="./" + imagePath, help='input image path')
-    parser.add_argument('--output', type=str, default="./result/" + imagePath + "_result.png", help='output image path')
     parser.add_argument('-k', '--kernel_size', type=int, default=10, help='larger kernel size means smooth color transition')
     parser.add_argument('-p', '--pixel_size', type=int, default=3, help='individual pixel size')
     parser.add_argument('-e', '--edge_thresh', type=int, default=2048, help='lower edge threshold means more black line in edge region')
     parser.add_argument('--resize', type=int, nargs=2, help='resize images to a fixed size (width height)')
     args = parser.parse_args()
 
+    # 出力ファイル名を生成
+    base_name = os.path.basename(imagePath)
+    file_name, file_extension = os.path.splitext(base_name)
+    output_file_name = f"{file_name}_k{args.kernel_size}_p{args.pixel_size}_e{args.edge_thresh}{file_extension}"
+    args.output = os.path.join("./result", output_file_name)
+    
     img_input = Image.open(args.input).convert("RGBA")
     
     if args.resize:

--- a/models/module_photo2pixel2.py
+++ b/models/module_photo2pixel2.py
@@ -14,25 +14,35 @@ class Photo2PixelModel(nn.Module):
         self.module_edge_detect = EdgeDetectorModule()
 
     def forward(self, rgb, alpha, param_kernel_size=10, param_pixel_size=16, param_edge_thresh=112):
-        """
-        アルファチャンネルを扱うための変更を加えます。
-        """
+        # RGBチャンネルの処理
         rgb = self.module_pixel_effect(rgb, 4, param_kernel_size, param_pixel_size)
 
         edge_mask = self.module_edge_detect(rgb, param_edge_thresh, param_edge_dilate=3)
         rgb = torch.masked_fill(rgb, torch.gt(edge_mask, 0.5), 0)
 
-        # アルファチャンネルは影響を受けないため、そのまま返します。
+        # アルファチャンネルの処理
+        alpha = self.process_alpha(alpha, param_kernel_size, param_pixel_size)
+
         return rgb, alpha
+
+    def process_alpha(self, alpha, param_kernel_size, param_pixel_size):
+        # アルファチャンネルを3チャンネルに複製
+        alpha_3channel = alpha.repeat(1, 3, 1, 1)
+        
+        # PixelEffectModuleを適用
+        alpha_processed = self.module_pixel_effect(alpha_3channel, 4, param_kernel_size, param_pixel_size)
+        
+        # 処理後、1チャンネルに戻す
+        return alpha_processed[:, 0:1, :, :]
 
 def test1():
     img = Image.open("../images/example_input_mountain.png").convert("RGBA")
     img_np = np.array(img).astype(np.float32)
     img_pt = np.transpose(img_np[:, :, :3], axes=[2, 0, 1])[np.newaxis, :, :, :]  # RGBのみをテンソルに変換
-    alpha_channel = img_np[:, :, 3:]  # アルファチャンネルを保持
+    alpha_channel = img_np[:, :, 3:].transpose(2, 0, 1)[np.newaxis, :, :, :]  # アルファチャンネルを同じ形状に変換
 
     img_pt = torch.from_numpy(img_pt)
-    alpha_channel = torch.from_numpy(alpha_channel).unsqueeze(0)  # アルファチャンネルの次元を調整
+    alpha_channel = torch.from_numpy(alpha_channel)
 
     model = Photo2PixelModel()
     model.eval()


### PR DESCRIPTION
これまではアルファチャンネルだけスムースな表現になってしまっていたが、これもピクセルアート化の処理の対象にした。
ついでにコンバート関数の引数にパラメータを渡して結果を試しやすくした。